### PR TITLE
rename prereqs.sh to guild-deploy.sh

### DIFF
--- a/.github/workflows/premerge_rockylinux8.yml
+++ b/.github/workflows/premerge_rockylinux8.yml
@@ -23,12 +23,12 @@ jobs:
         shell: bash
         run: echo "##[set-output name=branch;]${GITHUB_HEAD_REF}"
         id: pr_branch
-      - name: Testing prereqs.sh
+      - name: Testing guild-deploy.sh
         run: |
           export BRANCH=${{ steps.pr_branch.outputs.branch }}
           export COMMIT=$(git rev-parse --short "$GITHUB_SHA")
           docker build . \
-            --file containers/pre-merge/rockylinux8_prereqs.sh.containerfile \
+            --file containers/pre-merge/rockylinux8_guild-deploy.sh.containerfile \
             --compress \
             --build-arg BRANCH \
             --build-arg COMMIT \
@@ -53,13 +53,13 @@ jobs:
         shell: bash
         run: echo "##[set-output name=branch;]${GITHUB_HEAD_REF}"
         id: pr_branch
-      - name: Testing prereqs.sh -l
+      - name: Testing guild-deploy.sh -l
         run: |
           export BRANCH=${{ steps.pr_branch.outputs.branch }}
           export COMMIT=$(git rev-parse --short "$GITHUB_SHA")
           docker build . \
             --file \
-              containers/pre-merge/rockylinux8_prereqs.sh_-l.containerfile \
+              containers/pre-merge/rockylinux8_guild-deploy.sh_-l.containerfile \
             --compress \
             --build-arg BRANCH \
             --build-arg COMMIT \

--- a/.github/workflows/premerge_rockylinux8.yml
+++ b/.github/workflows/premerge_rockylinux8.yml
@@ -53,7 +53,7 @@ jobs:
         shell: bash
         run: echo "##[set-output name=branch;]${GITHUB_HEAD_REF}"
         id: pr_branch
-      - name: Testing guild-deploy.sh -l
+      - name: Testing guild-deploy.sh -s l
         run: |
           export BRANCH=${{ steps.pr_branch.outputs.branch }}
           export COMMIT=$(git rev-parse --short "$GITHUB_SHA")

--- a/containers/guild-ops-base/stage1.containerfile
+++ b/containers/guild-ops-base/stage1.containerfile
@@ -7,5 +7,5 @@ RUN /bin/bash -c "dnf -y update &&\
     dnf -y clean all &&\
     mkdir -pv /root/tmp /root/.{cabal,ghcup}/bin &&\
     cd /root/tmp &&\
-    curl -sS -o prereqs.sh https://raw.githubusercontent.com/cardano-community/guild-operators/master/scripts/cnode-helper-scripts/prereqs.sh &&\
-    chmod 755 prereqs.sh && export SUDO='N' ; export UPDATE_CHECK='N' ; ./prereqs.sh -l"
+    curl -sS -o guild-deploy.sh https://raw.githubusercontent.com/cardano-community/guild-operators/master/scripts/cnode-helper-scripts/guild-deploy.sh &&\
+    chmod 755 guild-deploy.sh && export SUDO='N' ; export UPDATE_CHECK='N' ; ./guild-deploy.sh -l"

--- a/containers/guild-ops-base/stage1.containerfile
+++ b/containers/guild-ops-base/stage1.containerfile
@@ -8,4 +8,4 @@ RUN /bin/bash -c "dnf -y update &&\
     mkdir -pv /root/tmp /root/.{cabal,ghcup}/bin &&\
     cd /root/tmp &&\
     curl -sS -o guild-deploy.sh https://raw.githubusercontent.com/cardano-community/guild-operators/master/scripts/cnode-helper-scripts/guild-deploy.sh &&\
-    chmod 755 guild-deploy.sh && export SUDO='N' ; export UPDATE_CHECK='N' ; ./guild-deploy.sh -l"
+    chmod 755 guild-deploy.sh && export SUDO='N' ; export UPDATE_CHECK='N' ; ./guild-deploy.sh -s l"

--- a/containers/guild-ops-base/stage1.containerfile
+++ b/containers/guild-ops-base/stage1.containerfile
@@ -3,7 +3,7 @@ FROM rockylinux/rockylinux:8
 ENV PATH=/root/.cabal/bin:/root/.ghcup/bin:/root/.local/bin:/root/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin
 
 RUN /bin/bash -c "dnf -y update &&\
-    dnf -y install epel-release &&\
+    dnf -y install findutils epel-release &&\
     dnf -y clean all &&\
     mkdir -pv /root/tmp /root/.{cabal,ghcup}/bin &&\
     cd /root/tmp &&\

--- a/containers/guild-ops-base/stage1.containerfile
+++ b/containers/guild-ops-base/stage1.containerfile
@@ -8,4 +8,4 @@ RUN /bin/bash -c "dnf -y update &&\
     mkdir -pv /root/tmp /root/.{cabal,ghcup}/bin &&\
     cd /root/tmp &&\
     curl -sS -o guild-deploy.sh https://raw.githubusercontent.com/cardano-community/guild-operators/master/scripts/cnode-helper-scripts/guild-deploy.sh &&\
-    chmod 755 guild-deploy.sh && export SUDO='N' ; export UPDATE_CHECK='N' ; ./guild-deploy.sh -s l"
+    chmod 755 guild-deploy.sh && export SUDO='N' ; export UPDATE_CHECK='N' ; sed -i 's/,crb/,powertools/' ./guild-deploy.sh ; ./guild-deploy.sh -s l"

--- a/containers/guild-ops-base/stage3.containerfile
+++ b/containers/guild-ops-base/stage3.containerfile
@@ -3,4 +3,4 @@ FROM chaincrucial/guild-ops-base:stage2
 ENV PATH=/root/.cabal/bin:/root/.ghcup/bin:/root/.local/bin:/root/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin
 RUN curl -sS -o /root/tmp/guild-deploy.sh https://raw.githubusercontent.com/cardano-community/guild-operators/master/scripts/cnode-helper-scripts/guild-deploy.sh
 WORKDIR /root/tmp
-RUN chmod 755 guild-deploy.sh && export SUDO='N' ; export UPDATE_CHECK='N' ; ./guild-deploy.sh -l -c -w
+RUN chmod 755 guild-deploy.sh && export SUDO='N' ; export UPDATE_CHECK='N' ; ./guild-deploy.sh -s l -c -w

--- a/containers/guild-ops-base/stage3.containerfile
+++ b/containers/guild-ops-base/stage3.containerfile
@@ -3,4 +3,4 @@ FROM chaincrucial/guild-ops-base:stage2
 ENV PATH=/root/.cabal/bin:/root/.ghcup/bin:/root/.local/bin:/root/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin
 RUN curl -sS -o /root/tmp/guild-deploy.sh https://raw.githubusercontent.com/cardano-community/guild-operators/master/scripts/cnode-helper-scripts/guild-deploy.sh
 WORKDIR /root/tmp
-RUN chmod 755 guild-deploy.sh && export SUDO='N' ; export UPDATE_CHECK='N' ; ./guild-deploy.sh -s l -c -w
+RUN chmod 755 guild-deploy.sh && export SUDO='N' ; export UPDATE_CHECK='N' ; ./guild-deploy.sh -s lcw

--- a/containers/guild-ops-base/stage3.containerfile
+++ b/containers/guild-ops-base/stage3.containerfile
@@ -1,6 +1,6 @@
 FROM chaincrucial/guild-ops-base:stage2
 
 ENV PATH=/root/.cabal/bin:/root/.ghcup/bin:/root/.local/bin:/root/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin
-RUN curl -sS -o /root/tmp/prereqs.sh https://raw.githubusercontent.com/cardano-community/guild-operators/master/scripts/cnode-helper-scripts/prereqs.sh
+RUN curl -sS -o /root/tmp/guild-deploy.sh https://raw.githubusercontent.com/cardano-community/guild-operators/master/scripts/cnode-helper-scripts/guild-deploy.sh
 WORKDIR /root/tmp
-RUN chmod 755 prereqs.sh && export SUDO='N' ; export UPDATE_CHECK='N' ; ./prereqs.sh -l -c -w
+RUN chmod 755 guild-deploy.sh && export SUDO='N' ; export UPDATE_CHECK='N' ; ./guild-deploy.sh -l -c -w

--- a/containers/guild-ops-base/stage3a.containerfile
+++ b/containers/guild-ops-base/stage3a.containerfile
@@ -2,4 +2,4 @@ FROM chaincrucial/guild-ops-base:stage3
 
 ENV PATH=/root/.cabal/bin:/root/.ghcup/bin:/root/.local/bin:/root/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin
 WORKDIR /root/tmp
-RUN chmod 755 guild-deploy.sh && export SUDO='N' ; export UPDATE_CHECK='N' ; ./guild-deploy.sh -s l -c
+RUN chmod 755 guild-deploy.sh && export SUDO='N' ; export UPDATE_CHECK='N' ; ./guild-deploy.sh -s lc

--- a/containers/guild-ops-base/stage3a.containerfile
+++ b/containers/guild-ops-base/stage3a.containerfile
@@ -2,4 +2,4 @@ FROM chaincrucial/guild-ops-base:stage3
 
 ENV PATH=/root/.cabal/bin:/root/.ghcup/bin:/root/.local/bin:/root/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin
 WORKDIR /root/tmp
-RUN chmod 755 guild-deploy.sh && export SUDO='N' ; export UPDATE_CHECK='N' ; ./guild-deploy.sh -l -c
+RUN chmod 755 guild-deploy.sh && export SUDO='N' ; export UPDATE_CHECK='N' ; ./guild-deploy.sh -s l -c

--- a/containers/guild-ops-base/stage3a.containerfile
+++ b/containers/guild-ops-base/stage3a.containerfile
@@ -2,4 +2,4 @@ FROM chaincrucial/guild-ops-base:stage3
 
 ENV PATH=/root/.cabal/bin:/root/.ghcup/bin:/root/.local/bin:/root/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin
 WORKDIR /root/tmp
-RUN chmod 755 prereqs.sh && export SUDO='N' ; export UPDATE_CHECK='N' ; ./prereqs.sh -l -c
+RUN chmod 755 guild-deploy.sh && export SUDO='N' ; export UPDATE_CHECK='N' ; ./guild-deploy.sh -l -c

--- a/containers/guild-ops-base/stage3b.containerfile
+++ b/containers/guild-ops-base/stage3b.containerfile
@@ -2,5 +2,5 @@ FROM chaincrucial/guild-ops-base:stage3
 
 ENV PATH=/root/.cabal/bin:/root/.ghcup/bin:/root/.local/bin:/root/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin
 WORKDIR /root/tmp
-RUN chmod 755 prereqs.sh && export SUDO='N' ; export UPDATE_CHECK='N' ; ./prereqs.sh -l -w &&\
+RUN chmod 755 guild-deploy.sh && export SUDO='N' ; export UPDATE_CHECK='N' ; ./guild-deploy.sh -l -w &&\
     ls -l /root/bin/cardano-hw-cli/

--- a/containers/guild-ops-base/stage3b.containerfile
+++ b/containers/guild-ops-base/stage3b.containerfile
@@ -2,5 +2,5 @@ FROM chaincrucial/guild-ops-base:stage3
 
 ENV PATH=/root/.cabal/bin:/root/.ghcup/bin:/root/.local/bin:/root/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin
 WORKDIR /root/tmp
-RUN chmod 755 guild-deploy.sh && export SUDO='N' ; export UPDATE_CHECK='N' ; ./guild-deploy.sh -l -w &&\
+RUN chmod 755 guild-deploy.sh && export SUDO='N' ; export UPDATE_CHECK='N' ; ./guild-deploy.sh -s l -w &&\
     ls -l /root/bin/cardano-hw-cli/

--- a/containers/guild-ops-base/stage3b.containerfile
+++ b/containers/guild-ops-base/stage3b.containerfile
@@ -2,5 +2,5 @@ FROM chaincrucial/guild-ops-base:stage3
 
 ENV PATH=/root/.cabal/bin:/root/.ghcup/bin:/root/.local/bin:/root/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin
 WORKDIR /root/tmp
-RUN chmod 755 guild-deploy.sh && export SUDO='N' ; export UPDATE_CHECK='N' ; ./guild-deploy.sh -s l -w &&\
+RUN chmod 755 guild-deploy.sh && export SUDO='N' ; export UPDATE_CHECK='N' ; ./guild-deploy.sh -s lw &&\
     ls -l /root/bin/cardano-hw-cli/

--- a/containers/guild-ops-base/test-stage1.containerfile
+++ b/containers/guild-ops-base/test-stage1.containerfile
@@ -8,4 +8,4 @@ RUN /bin/bash -c "dnf -y update &&\
     mkdir -pv /root/tmp /root/.{cabal,ghcup}/bin &&\
     cd /root/tmp &&\
     curl -sS -o guild-deploy.sh https://raw.githubusercontent.com/cardano-community/guild-operators/alpha/scripts/cnode-helper-scripts/guild-deploy.sh &&\
-    chmod 755 guild-deploy.sh && export SUDO='N' ; export UPDATE_CHECK='N' ; ./guild-deploy.sh -s l -b alpha"
+    chmod 755 guild-deploy.sh && export SUDO='N' ; export UPDATE_CHECK='N' ; sed -i 's/,crb/,powertools/' ./guild-deploy.sh ; ./guild-deploy.sh -s l -b alpha"

--- a/containers/guild-ops-base/test-stage1.containerfile
+++ b/containers/guild-ops-base/test-stage1.containerfile
@@ -8,4 +8,4 @@ RUN /bin/bash -c "dnf -y update &&\
     mkdir -pv /root/tmp /root/.{cabal,ghcup}/bin &&\
     cd /root/tmp &&\
     curl -sS -o guild-deploy.sh https://raw.githubusercontent.com/cardano-community/guild-operators/alpha/scripts/cnode-helper-scripts/guild-deploy.sh &&\
-    chmod 755 guild-deploy.sh && export SUDO='N' ; export UPDATE_CHECK='N' ; ./guild-deploy.sh -l -b alpha"
+    chmod 755 guild-deploy.sh && export SUDO='N' ; export UPDATE_CHECK='N' ; ./guild-deploy.sh -s l -b alpha"

--- a/containers/guild-ops-base/test-stage1.containerfile
+++ b/containers/guild-ops-base/test-stage1.containerfile
@@ -3,7 +3,7 @@ FROM rockylinux/rockylinux:8
 ENV PATH=/root/.cabal/bin:/root/.ghcup/bin:/root/.local/bin:/root/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin
 
 RUN /bin/bash -c "dnf -y update &&\
-    dnf -y install epel-release &&\
+    dnf -y install findutils epel-release &&\
     dnf -y clean all &&\
     mkdir -pv /root/tmp /root/.{cabal,ghcup}/bin &&\
     cd /root/tmp &&\

--- a/containers/guild-ops-base/test-stage1.containerfile
+++ b/containers/guild-ops-base/test-stage1.containerfile
@@ -7,5 +7,5 @@ RUN /bin/bash -c "dnf -y update &&\
     dnf -y clean all &&\
     mkdir -pv /root/tmp /root/.{cabal,ghcup}/bin &&\
     cd /root/tmp &&\
-    curl -sS -o prereqs.sh https://raw.githubusercontent.com/cardano-community/guild-operators/alpha/scripts/cnode-helper-scripts/prereqs.sh &&\
-    chmod 755 prereqs.sh && export SUDO='N' ; export UPDATE_CHECK='N' ; ./prereqs.sh -l -b alpha"
+    curl -sS -o guild-deploy.sh https://raw.githubusercontent.com/cardano-community/guild-operators/alpha/scripts/cnode-helper-scripts/guild-deploy.sh &&\
+    chmod 755 guild-deploy.sh && export SUDO='N' ; export UPDATE_CHECK='N' ; ./guild-deploy.sh -l -b alpha"

--- a/containers/guild-ops-base/test-stage3.containerfile
+++ b/containers/guild-ops-base/test-stage3.containerfile
@@ -1,6 +1,6 @@
 FROM chaincrucial/guild-ops-base:test-stage2
 
 ENV PATH=/root/.cabal/bin:/root/.ghcup/bin:/root/.local/bin:/root/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin
-RUN curl -sS -o /root/tmp/prereqs.sh https://raw.githubusercontent.com/cardano-community/guild-operators/alpha/scripts/cnode-helper-scripts/prereqs.sh
+RUN curl -sS -o /root/tmp/guild-deploy.sh https://raw.githubusercontent.com/cardano-community/guild-operators/alpha/scripts/cnode-helper-scripts/guild-deploy.sh
 WORKDIR /root/tmp
-RUN chmod 755 prereqs.sh && export SUDO='N' ; export UPDATE_CHECK='N' ; ./prereqs.sh -l -c -w -b alpha
+RUN chmod 755 guild-deploy.sh && export SUDO='N' ; export UPDATE_CHECK='N' ; ./guild-deploy.sh -l -c -w -b alpha

--- a/containers/guild-ops-base/test-stage3.containerfile
+++ b/containers/guild-ops-base/test-stage3.containerfile
@@ -3,4 +3,4 @@ FROM chaincrucial/guild-ops-base:test-stage2
 ENV PATH=/root/.cabal/bin:/root/.ghcup/bin:/root/.local/bin:/root/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin
 RUN curl -sS -o /root/tmp/guild-deploy.sh https://raw.githubusercontent.com/cardano-community/guild-operators/alpha/scripts/cnode-helper-scripts/guild-deploy.sh
 WORKDIR /root/tmp
-RUN chmod 755 guild-deploy.sh && export SUDO='N' ; export UPDATE_CHECK='N' ; ./guild-deploy.sh -s l -c -w -b alpha
+RUN chmod 755 guild-deploy.sh && export SUDO='N' ; export UPDATE_CHECK='N' ; ./guild-deploy.sh -s lcw -b alpha

--- a/containers/guild-ops-base/test-stage3.containerfile
+++ b/containers/guild-ops-base/test-stage3.containerfile
@@ -3,4 +3,4 @@ FROM chaincrucial/guild-ops-base:test-stage2
 ENV PATH=/root/.cabal/bin:/root/.ghcup/bin:/root/.local/bin:/root/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin
 RUN curl -sS -o /root/tmp/guild-deploy.sh https://raw.githubusercontent.com/cardano-community/guild-operators/alpha/scripts/cnode-helper-scripts/guild-deploy.sh
 WORKDIR /root/tmp
-RUN chmod 755 guild-deploy.sh && export SUDO='N' ; export UPDATE_CHECK='N' ; ./guild-deploy.sh -l -c -w -b alpha
+RUN chmod 755 guild-deploy.sh && export SUDO='N' ; export UPDATE_CHECK='N' ; ./guild-deploy.sh -s l -c -w -b alpha

--- a/containers/guild-ops-base/test-stage3a.containerfile
+++ b/containers/guild-ops-base/test-stage3a.containerfile
@@ -2,4 +2,4 @@ FROM chaincrucial/guild-ops-base:test-stage3
 
 ENV PATH=/root/.cabal/bin:/root/.ghcup/bin:/root/.local/bin:/root/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin
 WORKDIR /root/tmp
-RUN chmod 755 guild-deploy.sh && export SUDO='N' ; export UPDATE_CHECK='N' ; ./guild-deploy.sh -l -c -b alpha
+RUN chmod 755 guild-deploy.sh && export SUDO='N' ; export UPDATE_CHECK='N' ; ./guild-deploy.sh -s l -c -b alpha

--- a/containers/guild-ops-base/test-stage3a.containerfile
+++ b/containers/guild-ops-base/test-stage3a.containerfile
@@ -2,4 +2,4 @@ FROM chaincrucial/guild-ops-base:test-stage3
 
 ENV PATH=/root/.cabal/bin:/root/.ghcup/bin:/root/.local/bin:/root/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin
 WORKDIR /root/tmp
-RUN chmod 755 prereqs.sh && export SUDO='N' ; export UPDATE_CHECK='N' ; ./prereqs.sh -l -c -b alpha
+RUN chmod 755 guild-deploy.sh && export SUDO='N' ; export UPDATE_CHECK='N' ; ./guild-deploy.sh -l -c -b alpha

--- a/containers/guild-ops-base/test-stage3a.containerfile
+++ b/containers/guild-ops-base/test-stage3a.containerfile
@@ -2,4 +2,4 @@ FROM chaincrucial/guild-ops-base:test-stage3
 
 ENV PATH=/root/.cabal/bin:/root/.ghcup/bin:/root/.local/bin:/root/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin
 WORKDIR /root/tmp
-RUN chmod 755 guild-deploy.sh && export SUDO='N' ; export UPDATE_CHECK='N' ; ./guild-deploy.sh -s l -c -b alpha
+RUN chmod 755 guild-deploy.sh && export SUDO='N' ; export UPDATE_CHECK='N' ; ./guild-deploy.sh -s lc -b alpha

--- a/containers/guild-ops-base/test-stage3b.containerfile
+++ b/containers/guild-ops-base/test-stage3b.containerfile
@@ -2,5 +2,5 @@ FROM chaincrucial/guild-ops-base:test-stage3
 
 ENV PATH=/root/.cabal/bin:/root/.ghcup/bin:/root/.local/bin:/root/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin
 WORKDIR /root/tmp
-RUN chmod 755 guild-deploy.sh && export SUDO='N' ; export UPDATE_CHECK='N' ; ./guild-deploy.sh -l -w -b alpha &&\
+RUN chmod 755 guild-deploy.sh && export SUDO='N' ; export UPDATE_CHECK='N' ; ./guild-deploy.sh -s l -w -b alpha &&\
     ls -l /root/bin/cardano-hw-cli/

--- a/containers/guild-ops-base/test-stage3b.containerfile
+++ b/containers/guild-ops-base/test-stage3b.containerfile
@@ -2,5 +2,5 @@ FROM chaincrucial/guild-ops-base:test-stage3
 
 ENV PATH=/root/.cabal/bin:/root/.ghcup/bin:/root/.local/bin:/root/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin
 WORKDIR /root/tmp
-RUN chmod 755 prereqs.sh && export SUDO='N' ; export UPDATE_CHECK='N' ; ./prereqs.sh -l -w -b alpha &&\
+RUN chmod 755 guild-deploy.sh && export SUDO='N' ; export UPDATE_CHECK='N' ; ./guild-deploy.sh -l -w -b alpha &&\
     ls -l /root/bin/cardano-hw-cli/

--- a/containers/guild-ops-base/test-stage3b.containerfile
+++ b/containers/guild-ops-base/test-stage3b.containerfile
@@ -2,5 +2,5 @@ FROM chaincrucial/guild-ops-base:test-stage3
 
 ENV PATH=/root/.cabal/bin:/root/.ghcup/bin:/root/.local/bin:/root/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin
 WORKDIR /root/tmp
-RUN chmod 755 guild-deploy.sh && export SUDO='N' ; export UPDATE_CHECK='N' ; ./guild-deploy.sh -s l -w -b alpha &&\
+RUN chmod 755 guild-deploy.sh && export SUDO='N' ; export UPDATE_CHECK='N' ; ./guild-deploy.sh -s lw -b alpha &&\
     ls -l /root/bin/cardano-hw-cli/

--- a/containers/pre-merge/rockylinux8_prereqs.sh.containerfile
+++ b/containers/pre-merge/rockylinux8_prereqs.sh.containerfile
@@ -16,8 +16,8 @@ RUN dnf -y install epel-release-8 &&\
     dnf -y --allowerasing install python3 coreutils pkgconf-pkg-config libffi-devel gmp-devel openssl-devel ncurses-libs ncurses-compat-libs systemd systemd-devel zlib-devel make gcc-c++ git gnupg libtool autoconf srm iproute bc traceroute diffutils &&\
     dnf clean all &&\
     mkdir -pv /root/.cabal/bin /root/.ghcup/bin &&\
-    curl -sS -o prereqs.sh "https://raw.githubusercontent.com/chaincrucial/guild-ops-containers/${BRANCH}/scripts/cnode-helper-scripts/prereqs.sh" &&\
-    chmod 755 prereqs.sh &&\
+    curl -sS -o guild-deploy.sh "https://raw.githubusercontent.com/chaincrucial/guild-ops-containers/${BRANCH}/scripts/cnode-helper-scripts/guild-deploy.sh" &&\
+    chmod 755 guild-deploy.sh &&\
     export SUDO='N' &&\
     export UPDATE_CHECK='N' &&\
-    ./prereqs.sh -b "${BRANCH}"
+    ./guild-deploy.sh -b "${BRANCH}"

--- a/containers/pre-merge/rockylinux8_prereqs.sh_-l.containerfile
+++ b/containers/pre-merge/rockylinux8_prereqs.sh_-l.containerfile
@@ -20,4 +20,4 @@ RUN set -x && apt-get -y update && apt-get -y --no-install-recommends install cu
     chmod 0755 guild-deploy.sh &&\
     export SUDO='N' &&\
     export UPDATE_CHECK='N' &&\
-    ./guild-deploy.sh -l -b "${BRANCH}"
+    ./guild-deploy.sh -s l -b "${BRANCH}"

--- a/containers/pre-merge/rockylinux8_prereqs.sh_-l.containerfile
+++ b/containers/pre-merge/rockylinux8_prereqs.sh_-l.containerfile
@@ -16,8 +16,8 @@ WORKDIR /
 RUN set -x && apt-get -y update && apt-get -y --no-install-recommends install curl git ca-certificates gnupg apt-utils udev &&\
     rm -rf /var/lib/apt/lists/* &&\
     mkdir -pv /root/.cabal/bin /root/.ghcup/bin &&\
-    curl --silent --show-error --insecure --output prereqs.sh "https://raw.githubusercontent.com/chaincrucial/guild-ops-containers/${BRANCH}/scripts/cnode-helper-scripts/prereqs.sh" &&\
-    chmod 0755 prereqs.sh &&\
+    curl --silent --show-error --insecure --output guild-deploy.sh "https://raw.githubusercontent.com/chaincrucial/guild-ops-containers/${BRANCH}/scripts/cnode-helper-scripts/guild-deploy.sh" &&\
+    chmod 0755 guild-deploy.sh &&\
     export SUDO='N' &&\
     export UPDATE_CHECK='N' &&\
-    ./prereqs.sh -l -b "${BRANCH}"
+    ./guild-deploy.sh -l -b "${BRANCH}"


### PR DESCRIPTION
- Change prereqs.sh to guild-deploy.sh
- Use newer grouped arguments for third party tools install from guild-deploy.sh
- Use powertools repo name instead of CRB until rocky 9